### PR TITLE
Added typing stub file

### DIFF
--- a/libsql_experimental.pyi
+++ b/libsql_experimental.pyi
@@ -1,0 +1,65 @@
+"""Type stubs for libSQL's rust extensions"""
+
+from typing import Any, Sequence, Optional, Literal
+from typing_extensions import Self
+
+
+IsolationLevel = Literal['DEFERRED', 'IMMEDIATE', 'EXCLUSIVE']
+
+
+class Cursor:
+    """libSQL database cursor.
+
+    Implements a superset of the [DB-API 2.0 (PEP249)](https://peps.python.org/pep-0249/) Cursor object protocol."""  # noqa: E501
+    @property
+    def description(self) -> Optional[Sequence[Sequence[Any]]]: ...
+
+    @property
+    def rowcount(self) -> int: ...
+
+    @property
+    def arraysize(self) -> int: ...
+
+    @property
+    def lastrowid(self) -> Optional[int]: ...
+
+    def close(self) -> None: ...
+    def execute(self, sql: str, parameters: Sequence[Any] = ...) -> Self: ...
+    def executemany(self, sql: str, parameters: Sequence[Sequence[Any]] = ...) -> Self: ...  # noqa: E501
+    def fetchone(self) -> Optional[Sequence[Any]]: ...
+    def fetchmany(self, size: int = ...) -> Optional[Sequence[Sequence[Any]]]: ...  # noqa: E501
+    def fetchall(self) -> Optional[Sequence[Sequence[Any]]]: ...
+
+
+class Connection:
+    """libSQL database connection.
+
+    Implements a superset of the [DB-API 2.0 (PEP249)](https://peps.python.org/pep-0249/) Connection object protocol."""  # noqa: E501
+    @property
+    def autocommit(self) -> bool: ...
+
+    @property
+    def isolation_level(self) -> Optional[IsolationLevel]: ...
+
+    @property
+    def in_transaction(self) -> bool: ...
+
+    def commit(self) -> None: ...
+    def cursor(self) -> Cursor: ...
+    def sync(self) -> None: ...
+    def rollback(self) -> None: ...
+    def execute(self, sql: str, parameters: Sequence[Any] = ...) -> Cursor: ...
+    def executemany(self, sql: str, parameters: Sequence[Sequence[Any]] = ...) -> Cursor: ...  # noqa: E501
+    def executescript(self, script: str) -> None: ...
+
+
+def connect(database: str,
+            isolation_level: Optional[IsolationLevel] = ...,
+            check_same_thread: bool = ...,
+            uri: bool = ...,
+            sync_url: str = ...,
+            sync_interval: float = ...,
+            auth_token: str = ...,
+            encryption_key: str = ...) -> Connection:
+    """Open a new libSQL connection, return a Connection object."""
+    ...


### PR DESCRIPTION
This adds a stub file, adding type hints in Python. This added the `connect` function as well as the `Connection` and `Cursor` classes. Everything is in the `libsql_experimental.pyi` file. According to [this](https://pyo3.rs/v0.21.0-beta.0/python-typing-hints#if-you-do-not-have-other-python-files) PyO3 documentation, as long as there is no other Python files (excluding examples) Maturin will automatically install this file correctly, adding `__init__.pyi` and `py.typed` to site-packages. Below is a before and after example for the `connect` function. 

If there is anything I missed or misunderstood, let me know and ill fix it :)
 
![before](https://github.com/tursodatabase/libsql-experimental-python/assets/42066957/e890f7c7-1f06-4980-8d89-1e3ee604190f)
![after](https://github.com/tursodatabase/libsql-experimental-python/assets/42066957/4c113f44-ef34-48cb-80c6-c86b1beed9fb)
