### PR TITLE
fix cast to i32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ fn convert_row(py: Python, row: libsql_core::Row, column_count: i32) -> PyResult
         let libsql_value = row.get_value(col_idx).map_err(to_py_err)?;
         let value = match libsql_value {
             libsql_core::Value::Integer(v) => {
-                let value = v as i32;
+                let value = v as i64;
                 value.into_py(py)
             }
             libsql_core::Value::Real(v) => v.into_py(py),

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -173,6 +173,15 @@ def test_fetch_expression(provider):
     res = cur.execute("SELECT QUOTE(email) FROM users")
     assert [("'alice@example.com'",)] == res.fetchall()
 
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
+def test_int64(provider):
+    conn = connect(provider, ":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE data (id INTEGER, number INTEGER)")
+    conn.commit()
+    cur.execute("INSERT INTO data VALUES (1, 1099511627776)") # 1 << 40
+    res = cur.execute("SELECT * FROM data")
+    assert [(1,1099511627776)] == res.fetchall()
 
 def connect(provider, database, isolation_level='DEFERRED'):
     if provider == "libsql-remote":


### PR DESCRIPTION
as per https://www.sqlite.org/datatype3.html the cast to i32 was incorrect as sqlite supports 64 bit integers