### PR TITLE
feat: accept None as a param type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,9 @@ async fn execute(cursor: &Cursor, sql: String, parameters: Option<&PyTuple>) -> 
         Some(parameters) => {
             let mut params = vec![];
             for param in parameters.iter() {
-                let param = if let Ok(value) = param.extract::<i32>() {
+                let param = if param.is_none() {
+                    libsql_core::Value::Null
+                } else if let Ok(value) = param.extract::<i32>() {
                     libsql_core::Value::Integer(value as i64)
                 } else if let Ok(value) = param.extract::<f64>() {
                     libsql_core::Value::Real(value)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -238,6 +238,7 @@ def test_params(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "alice@example.com") == res.fetchone()
 
+@pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_none_param(provider):
     conn = connect(provider, ":memory:")
     cur = conn.cursor()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -244,7 +244,7 @@ def test_none_param(provider):
     cur = conn.cursor()
     cur.execute("CREATE TABLE users (id INTEGER, email TEXT)")
     cur.execute("INSERT INTO users VALUES (?, ?)", (1, None))
-    cur.execute("INSERT INTO users VALUES (?, ?)", (1, "alice@example.com"))
+    cur.execute("INSERT INTO users VALUES (?, ?)", (2, "alice@example.com"))
     res = cur.execute("SELECT * FROM users ORDER BY id")
     results = res.fetchall()
     assert results[0] == (1, None)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -238,6 +238,16 @@ def test_params(provider):
     res = cur.execute("SELECT * FROM users")
     assert (1, "alice@example.com") == res.fetchone()
 
+def test_none_param(provider):
+    conn = connect(provider, ":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE users (id INTEGER, email TEXT)")
+    cur.execute("INSERT INTO users VALUES (?, ?)", (1, None))
+    cur.execute("INSERT INTO users VALUES (?, ?)", (1, "alice@example.com"))
+    res = cur.execute("SELECT * FROM users ORDER BY id")
+    results = res.fetchall()
+    assert results[0] == (1, None)
+    assert results[1] == (2, "alice@example.com")
 
 @pytest.mark.parametrize("provider", ["libsql", "sqlite"])
 def test_fetchmany(provider):


### PR DESCRIPTION
Attempts to fix #51 and various other mentions of `None` support:

* https://github.com/tursodatabase/libsql-experimental-python/issues/62#issuecomment-2366789194
* https://github.com/tursodatabase/libsql-experimental-python/issues/62#issuecomment-2231236038
* https://github.com/tursodatabase/libsql-experimental-python/issues/59

I haven't checked @levydsa if there's something in libsql-c we do differently for cases like this (and if we plan to replace the internals here with those bindings).