### PR TITLE
additional documentation for libsql sync example

### DIFF
--- a/examples/sync/.gitignore
+++ b/examples/sync/.gitignore
@@ -1,1 +1,3 @@
 local.db*
+.env
+__pycache__/

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -1,19 +1,41 @@
-# Local
+# Sync Embedded Replica
 
-This example demonstrates how to use libSQL with a synced database (local file synced with a remote database).
+This example demonstrates how to use libSQL with a synced database (local file synced with a remote Turso database).
 
 ## Install Dependencies
 
 ```bash
-pip install libsql
+pip install python-dotenv
 ```
 
+**Requirements:**
+- An existing database on Turso cloud.
+- A `.env` file with your Turso DB credentials.
+
+Setup:
+1. Create a new database with:
+```bash
+turso db create <your_database_name>
+```
+2. Get your database URL:
+```bash
+turso db show <your_database_name>
+```
+3. Create an auth token:
+```bash
+turso db tokens create <your_database_name>
+```
+4. Add the URL and token to a `.env` file in your project root:
+```dotenv
+TURSO_DATABASE_URL=<your_database_url>
+TURSO_AUTH_TOKEN=<your_auth_token>
+```
 ## Running
 
 Execute the example:
 
 ```bash
-TURSO_DATABASE_URL="..." TURSO_AUTH_TOKEN="..." python3 main.py
+python3 main.py
 ```
 
 This will create a local database file that syncs with a remote database, insert some data, and query it.

--- a/examples/sync/main.py
+++ b/examples/sync/main.py
@@ -1,5 +1,34 @@
+"""
+Local Example: Using libSQL with a synced Turso database
+
+This script demonstrates how to use libSQL with a local database file
+that syncs with a remote Turso database.
+
+Requirements:
+- An existing database on Turso cloud.
+- A `.env` file with your Turso database credentials.
+
+Setup:
+1. Create a new database with:
+       turso db create <your_database_name>
+
+2. Get your database URL:
+       turso db show <your_database_name>
+
+3. Create an auth token:
+       turso db tokens create <your_database_name>
+
+4. Add the URL and token to a `.env` file in your project root:
+       TURSO_DATABASE_URL=<your_database_url>
+       TURSO_AUTH_TOKEN=<your_auth_token>
+
+"""
+
 import libsql
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 url = os.getenv("TURSO_DATABASE_URL")
 auth_token = os.getenv("TURSO_AUTH_TOKEN")


### PR DESCRIPTION
## Summary

This PR improves the documentation and example for using libSQL with a synced Turso database. The updates make setup clearer and replaces command line environment variables with a `.env` file for easier configuration.

## Changes

### README.md
- Updated install instructions:
  - Added `python-dotenv` dependency to support loading `.env` file.
- Added **Requirements** section explaining an existing Turso cloud database and `.env` file are needed.
- Expanded setup steps to include creating a new db in Turso CLI:
  - Included `turso db create`, `turso db show`, and `turso db tokens create`.
  - Added example `.env` file snippet.
- Simplified run instructions:
  - Now uses `python3 main.py` and a '.env' file in place of inline environment variables. 

### main.py
- Added a detailed docstring with more explicit instructions, requirements and setup steps. 
 - Added `from dotenv import load_dotenv` and `load_dotenv()` for compatibility with '.env' file. 

## Motivation

The original example was functional but assumed prior knowledge that could frustrate new users:

- It implicitly required an existing Turso database, without guidance on how to create one.
- There were no instructions for obtaining or using Turso database credentials.
- Users were expected to inline environment variables at runtime, which is less typical in Python and inconsistent with common practice.

Because embedded sync is a common entry point for developers new to libSQL and Turso, this update improves usability by:

- Providing a complete, self-contained setup workflow for first-time users.
- Adding `.env` support via `python-dotenv` to align with Python best practices for managing credentials.

## Testing

- Verified that the example runs successfully using a `.env` file with valid `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` values.
- Confirmed that the local database syncs correctly, the `users` table is created, and expected query results are printed.